### PR TITLE
feat: add astro-language-server and typescript to devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,13 +47,13 @@
             ];
 
             shellHook = ''
+              export NODE_PATH="${pkgs.typescript}/lib/node_modules''${NODE_PATH:+:''$NODE_PATH}"
+
               echo "🔥 Astro Sandbox Dev Shell 🚀"
               echo "Node.js $(node -v)"
               echo "pnpm $(pnpm -v)"
               echo "Astro LS $(astro-ls --version 2>/dev/null || echo 'not found')"
               echo "TypeScript $(tsc --version 2>/dev/null || echo 'not found')"
-
-              export NODE_PATH="${pkgs.typescript}/lib/node_modules:$NODE_PATH"
             '';
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -42,12 +42,18 @@
             packages = with pkgs; [
               nodejs_24
               pnpm
+              astro-language-server
+              typescript
             ];
 
             shellHook = ''
               echo "🔥 Astro Sandbox Dev Shell 🚀"
               echo "Node.js $(node -v)"
               echo "pnpm $(pnpm -v)"
+              echo "Astro LS $(astro-ls --version 2>/dev/null || echo 'not found')"
+              echo "TypeScript $(tsc --version 2>/dev/null || echo 'not found')"
+
+              export NODE_PATH="${pkgs.typescript}/lib/node_modules:$NODE_PATH"
             '';
           };
         };


### PR DESCRIPTION
Added astro-language-server and typescript to the development environment. 
Configured NODE_PATH in shellHook to resolve the 'Cannot find module typescript' error when running astro-ls.