### PR TITLE
ci: update node version to 24.x for textlint workflow

### DIFF
--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec textlint src/content/blog/*


### PR DESCRIPTION
Updates the `node-version` matrix/parameter from `22.x` to `24.x` in `.github/workflows/textlint.yml` to run the textlint checks on the newer Node.js version.

---
*PR created automatically by Jules for task [18179941262962916129](https://jules.google.com/task/18179941262962916129) started by @yuys13*