### PR TITLE
ci: add dependabot configuration for nix ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,12 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      nix:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a new update configuration in `.github/dependabot.yml` for the `nix` package ecosystem to keep `flake.lock` up to date. It runs on a weekly schedule and groups all nix updates into a single PR for easier review.

---
*PR created automatically by Jules for task [13223915208552091619](https://jules.google.com/task/13223915208552091619) started by @yuys13*