### PR TITLE
chore: migrate yamlfmt config to .yamlfmt

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,2 @@
+exclude:
+  - pnpm-lock.yaml

--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,7 @@
           treefmt.config = {
             projectRootFile = "flake.nix";
             programs.nixfmt.enable = true;
-            programs.yamlfmt = {
-              enable = true;
-              excludes = [ "pnpm-lock.yaml" ];
-            };
+            programs.yamlfmt.enable = true;
             programs.prettier = {
               enable = true;
               excludes = [


### PR DESCRIPTION
## Summary
This PR migrates the yamlfmt configuration from flake.nix to a dedicated .yamlfmt file. It also ensures that pnpm-lock.yaml is excluded from formatting.

## Changes
- Created .yamlfmt with exclude rules.
- Updated flake.nix to remove redundant exclude configurations for yamlfmt.

## Verification
- Ran 'nix fmt' and confirmed that pnpm-lock.yaml is not modified.