### PR TITLE
chore: optimize and organize treefmt configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         {
           treefmt.config = {
             projectRootFile = "flake.nix";
+            settings.global.excludes = [ "pnpm-lock.yaml" ];
             programs.nixfmt.enable = true;
             programs.yamlfmt.enable = true;
             programs.prettier = {

--- a/flake.nix
+++ b/flake.nix
@@ -28,16 +28,18 @@
         {
           treefmt.config = {
             projectRootFile = "flake.nix";
-            settings.global.excludes = [ "pnpm-lock.yaml" ];
-            programs.nixfmt.enable = true;
-            programs.yamlfmt.enable = true;
-            programs.prettier = {
-              enable = true;
-              excludes = [
-                "*.yml"
-                "*.yaml"
-              ];
+            programs = {
+              nixfmt.enable = true;
+              prettier = {
+                enable = true;
+                excludes = [
+                  "*.yml"
+                  "*.yaml"
+                ];
+              };
+              yamlfmt.enable = true;
             };
+            settings.global.excludes = [ "pnpm-lock.yaml" ];
           };
 
           devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary
This PR optimizes the `treefmt` configuration by excluding `pnpm-lock.yaml` at the global level and reorganizing the `treefmt.config` structure in `flake.nix`.

## Changes
- Added `pnpm-lock.yaml` to `settings.global.excludes` in `treefmt.config`. This prevents `treefmt` from scanning the file, improving performance.
- Reorganized `treefmt.config` by sorting entries and wrapping individual program settings into a single `programs` block for better readability.
- Maintained `.yamlfmt` configuration to ensure the exclude rule still applies when `yamlfmt` is run independently (e.g., via editor integration).

## Verification
- Confirmed with `nix fmt -- -vv` that `pnpm-lock.yaml` is now skipped early by the global exclude rule.