### PR TITLE
ci: add macOS support to Nix workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,7 +8,10 @@ permissions:
   contents: read
 jobs:
   nix-check:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Updated the `.github/workflows/nix.yml` workflow to use a strategy matrix, running the Nix CI checks on both `ubuntu-latest` and `macos-latest` as requested.

---
*PR created automatically by Jules for task [17868809197379594057](https://jules.google.com/task/17868809197379594057) started by @yuys13*