### PR TITLE
chore: suppress pnpm build script warnings and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 
 # dependencies
 node_modules/
+.pnpm-store/
 
 # logs
 npm-debug.log*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: false
+  sharp: false


### PR DESCRIPTION
## Description

This PR addresses the warnings regarding ignored build scripts that occur during `pnpm install`.

### Changes

- Added `pnpm-workspace.yaml` with `allowBuilds` set to `false` for `esbuild` and `sharp` to suppress pnpm v10 warnings.
- Updated `.gitignore` to include `.pnpm-store/` to prevent local pnpm cache from being tracked.

### Validation

- Confirmed that `pnpm install` no longer produces warnings.
- Verified that `pnpm build` still completes successfully.