### PR TITLE
chore: update pnpm to 11.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "textlint-rule-preset-ja-technical-writing": "^10.0.2",
     "vite": "^8.0.11"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.0.6"
 }


### PR DESCRIPTION
Updates the pnpm version to 11.0.6 in package.json. The lockfile remains compatible (v9.0).