### PR TITLE
chore: delay package updates by 1 day for pnpm and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -20,6 +22,8 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    cooldown:
+      default-days: 1
   - package-ecosystem: "nix"
     directory: "/"
     schedule:
@@ -28,3 +32,5 @@ updates:
       nix:
         patterns:
           - "*"
+    cooldown:
+      default-days: 1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-minimumReleaseAge: 1440
+minimumReleaseAge: 1440 # 1 day (in minutes)
 allowBuilds:
   esbuild: false
   sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+minimumReleaseAge: 1440
 allowBuilds:
   esbuild: false
   sharp: false


### PR DESCRIPTION
This PR introduces a 1-day delay for package updates to mitigate the risk of supply chain attacks and ensure that updates have been verified by the community.

### Changes:
- pnpm: Added minimumReleaseAge: 1440 to pnpm-workspace.yaml.
- Dependabot: Added cooldown: default-days: 1 to all package ecosystems in .github/dependabot.yml.