### PR TITLE
chore(deps): remove cooldown for nix in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,5 +32,3 @@ updates:
       nix:
         patterns:
           - "*"
-    cooldown:
-      default-days: 1


### PR DESCRIPTION
This PR removes the cooldown configuration for the nix ecosystem. The cooldown is unnecessary for nix because updates are already reviewed by maintainers.