### PR TITLE
ci: update nix workflow to split check and build jobs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,6 +8,18 @@ permissions:
   contents: read
 jobs:
   nix-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Flake check
+        run: nix flake check --all-systems
+  nix-build:
+    needs: nix-check
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -19,10 +31,6 @@ jobs:
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - name: Flake check
-        run: nix flake check
-      - name: Format check
-        run: nix fmt -- --fail-on-change --no-cache
       - name: Install dependencies
         run: nix develop --command pnpm install --frozen-lockfile
       - name: Astro check


### PR DESCRIPTION
This PR updates the `.github/workflows/nix.yml` workflow by splitting the existing `nix-check` job into two separate jobs:
- **`nix-check`**: Runs exclusively on `ubuntu-latest`. It executes `nix flake check --all-systems`. The redundant `nix fmt` step has been removed since it is covered by the flake check.
- **`nix-build`**: Runs on an OS matrix (`ubuntu-latest` and `macos-latest`) and explicitly depends on the `nix-check` job. It runs the remaining tasks (`pnpm install`, `astro check`, `textlint`, and `pnpm build`).

In this iteration, the job names were changed to `nix-check` and `nix-build` per PR comments.

---
*PR created automatically by Jules for task [9725262451484972074](https://jules.google.com/task/9725262451484972074) started by @yuys13*