### PR TITLE
ci: add Node.js 26.x to test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Added Node.js 26.x to the CI test matrix in `.github/workflows/node.js.yml` to ensure compatibility with the latest Node.js version.

---
*PR created automatically by Jules for task [7831344883094550703](https://jules.google.com/task/7831344883094550703) started by @yuys13*