### PR TITLE
chore: update node version to 24 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6.1.1
         with:
           # path: . # リポジトリ内のAstroプロジェクトのルートロケーション。(オプション)
-          node-version: 22 # サイト構築に使用するNodeのバージョン。デフォルトは18です。（オプション）
+          node-version: 24 # サイト構築に使用するNodeのバージョン。デフォルトは18です。（オプション）
           # package-manager: pnpm@latest # 依存関係のインストールとサイトのビルドに使用する Node パッケージマネージャ。ロックファイルに基づいて自動的に検出されます。(オプション)
   deploy:
     needs: build


### PR DESCRIPTION
Updates the `node-version` parameter from 22 to 24 in `.github/workflows/deploy.yml` to use the latest version specified by the user.

- Modified `.github/workflows/deploy.yml` to set `node-version: 24` in the `withastro/action` build step.
- Verified build succeeds locally using `pnpm install`, `pnpm run astro check`, and `pnpm run build`.

---
*PR created automatically by Jules for task [11207443768658922461](https://jules.google.com/task/11207443768658922461) started by @yuys13*